### PR TITLE
[ISSUE 1] Added underscore to camel case helper method to abstract module

### DIFF
--- a/src/main/java/org/mybatis/guice/MyBatisModule.java
+++ b/src/main/java/org/mybatis/guice/MyBatisModule.java
@@ -175,6 +175,15 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
     protected final void failFast(boolean failFast) {
         bindBoolean("mybatis.configuration.failFast", failFast);
     }
+  
+    /**
+     * Maps underscores to camel case.
+     *
+     * @param mapUnderscoreToCamelCase Toggles this settings value.
+     */
+    protected final void mapUnderscoreToCamelCase(boolean mapUnderscoreToCamelCase) {
+        bindBoolean("mybatis.configuration.mapUnderscoreToCamelCase", mapUnderscoreToCamelCase);
+    }
 
     /**
      *


### PR DESCRIPTION
Here's the change. It doesn't look like there are any unit tests that cover the setting methods of the MyBatisModule, so I didn't add a test for this change.
