### PR TITLE
Updated POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,20 +14,21 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>21</version>
+    <version>22-SNAPSHOT</version>
   </parent>
 
   <artifactId>mybatis-guice</artifactId>
   <version>3.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>MyBatis Guice</name>
+  <name>mybatis-guice</name>
   <description>The MyBatis Guice module is easy-to-use Google Guice bridge for MyBatis sql mapping framework.</description>
   <url>http://www.mybatis.org/guice/</url>
 
@@ -94,7 +95,7 @@
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.6</version>
+      <version>3.2.7</version>
       <scope>provided</scope>
     </dependency>
 
@@ -112,13 +113,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>net.sourceforge.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.2</version>
-      <scope>provided</scope>
-    </dependency>
-            
     <!--
      | Optional dependencies
     -->
@@ -156,41 +150,15 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.2.9</version>
+      <version>2.3.2</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.7</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.jdmk</groupId>
-          <artifactId>jmxtools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jmx</groupId>
-          <artifactId>jmxri</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.jms</groupId>
-          <artifactId>jms</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.mail</groupId>
-          <artifactId>mail</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>oro</groupId>
-          <artifactId>oro</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Use proper XSD for maven
Updated to mybatis-parent 22-SNAPSHOT
Changed <name> to match <artifactId>
Updated mybatis to 3.2.7
Removed findbugs dependency - wasn't part of project and was extremely
old
Updated hsqldb to 2.3.2
Replaced log4j test dependency with slf4j-simple which fixes warnings in
maven and still logs properly.
