### PR TITLE
added DBCP.timeBetweenEvictionRunsMillis

### DIFF
--- a/src/main/java/org/mybatis/guice/datasource/dbcp/BasicDataSourceProvider.java
+++ b/src/main/java/org/mybatis/guice/datasource/dbcp/BasicDataSourceProvider.java
@@ -275,6 +275,16 @@ public final class BasicDataSourceProvider implements Provider<DataSource> {
     /**
      *
      *
+     * @param timeBetweenEvictionRunsMillis
+     */
+    @com.google.inject.Inject(optional = true)
+    public void setTimeBetweenEvictionRunsMillis(@Named("DBCP.timeBetweenEvictionRunsMillis") int timeBetweenEvictionRunsMillis) {
+        dataSource.setTimeBetweenEvictionRunsMillis(timeBetweenEvictionRunsMillis);
+    }
+
+    /**
+     *
+     *
      * @param validationQuery
      */
     @com.google.inject.Inject(optional = true)


### PR DESCRIPTION
as injected property in ```BasicDataSourceProvider```. 
I don't know what's the difference between ```BasicDataSourceProvider``` and ```SharedPoolDataSourceProvider```, so I didn't add other "missing" properties like ```DBCP.rollbackAfterValidation```. 