### PR TITLE
JdbcHelper for MariaDB

### DIFF
--- a/src/main/java/org/mybatis/guice/datasource/helper/JdbcHelper.java
+++ b/src/main/java/org/mybatis/guice/datasource/helper/JdbcHelper.java
@@ -75,6 +75,8 @@ public enum JdbcHelper implements Module {
 
     JDBC_ODBC_Bridge("jdbc:odbc:${ODBC.datasource}", "sun.jdbc.odbc.JdbcOdbcDriver"),
 
+    MariaDB("jdbc:mysql://${JDBC.host|localhost}:${JDBC.port|3306}/${JDBC.schema}", "org.mariadb.jdbc.Driver"),
+
     MaxDB("jdbc:sapdb://${JDBC.host|localhost}:${JDBC.port|7210}/${JDBC.schema}", "com.sap.dbtech.jdbc.DriverSapDB"),
 
     McKoi("jdbc:mckoi://${JDBC.host|localhost}:${JDBC.port|9157}/${JDBC.schema}", "com.mckoi.JDBCDriver"),

--- a/src/site/xdoc/jdbc-helper.xml
+++ b/src/site/xdoc/jdbc-helper.xml
@@ -157,6 +157,10 @@ InformixServer=${informixserver};DatabaseServer=${JDBC.schema}</code></td>
                         <td><code>jdbc:odbc:${ODBC.datasource}</code></td>
                     </tr>
                     <tr>
+                        <td><code>JdbcHelper.MariaDB</code></td>
+                        <td><code>jdbc:mysql://${JDBC.host|localhost}:${JDBC.port|3306}/${JDBC.schema}</code></td>
+                    </tr>
+                    <tr>
                         <td><code>JdbcHelper.MaxDB</code></td>
                         <td><code>jdbc:sapdb://${JDBC.host|localhost}:${JDBC.port|7210}/${JDBC.schema}</code></td>
                     </tr>


### PR DESCRIPTION
Hi,

I build web app with Guice + MyBatis + MariaDB and JdbcHelper for MariaDB is missing, so i added it. MariaDB is a fork of MySQL so that's why they have same url template, but different drivers.

Cheers.