### PR TITLE
Abstract configuration settings

### DIFF
--- a/src/main/java/org/mybatis/guice/MyBatisModule.java
+++ b/src/main/java/org/mybatis/guice/MyBatisModule.java
@@ -60,6 +60,7 @@ import org.mybatis.guice.configuration.settings.ConfigurationSettings;
 import org.mybatis.guice.configuration.settings.DefaultExecutorTypeConfigurationSetting;
 import org.mybatis.guice.configuration.settings.DefaultScriptingLanguageTypeConfigurationSetting;
 import org.mybatis.guice.configuration.settings.DefaultStatementTimeoutConfigurationSetting;
+import org.mybatis.guice.configuration.settings.FailFastSettingImpl;
 import org.mybatis.guice.configuration.settings.LazyLoadingEnabledConfigurationSetting;
 import org.mybatis.guice.configuration.settings.LocalCacheScopeConfigurationSetting;
 import org.mybatis.guice.configuration.settings.MapUnderscoreToCamelCaseConfigurationSetting;
@@ -234,7 +235,7 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
      * @param failFast
      */
     protected final void failFast(boolean failFast) {
-//        bindBoolean("mybatis.configuration.failFast", failFast);
+        bindConstant().annotatedWith(FailFastSettingImpl.get()).to(failFast);
     }
 
     /**

--- a/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
@@ -15,30 +15,24 @@
  */
 package org.mybatis.guice.configuration;
 
-import com.google.inject.ProvisionException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.sql.DataSource;
 
 import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.plugin.Interceptor;
-import org.apache.ibatis.reflection.factory.ObjectFactory;
-import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
-import org.apache.ibatis.scripting.LanguageDriver;
-import org.apache.ibatis.session.AutoMappingBehavior;
 import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.type.TypeHandler;
+import org.mybatis.guice.configuration.settings.ConfigurationSetting;
+import org.mybatis.guice.configuration.settings.ConfigurationSettings;
 
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Provider;
-import javax.inject.Singleton;
-import javax.sql.DataSource;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
+import com.google.inject.ProvisionException;
 
 /**
  * Provides the myBatis Configuration.
@@ -50,60 +44,6 @@ public class ConfigurationProvider implements Provider<Configuration> {
      * The myBatis Configuration reference.
      */
     private final Environment environment;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.lazyLoadingEnabled")
-    private boolean lazyLoadingEnabled = false;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.aggressiveLazyLoading")
-    private boolean aggressiveLazyLoading = true;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.multipleResultSetsEnabled")
-    private boolean multipleResultSetsEnabled = true;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.useGeneratedKeys")
-    private boolean useGeneratedKeys = false;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.useColumnLabel")
-    private boolean useColumnLabel = true;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.cacheEnabled")
-    private boolean cacheEnabled = true;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.defaultExecutorType")
-    private ExecutorType defaultExecutorType = ExecutorType.SIMPLE;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.autoMappingBehavior")
-    private AutoMappingBehavior autoMappingBehavior = AutoMappingBehavior.PARTIAL;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.failFast")
-    private boolean failFast = false;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.callSettersOnNulls")
-    private boolean callSettersOnNulls = false;
-
-    @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.defaultStatementTimeout")
-    @Nullable
-    private Integer defaultStatementTimeout;
-
-    @Inject
-    private ObjectFactory objectFactory;
-
-    @Inject
-    private ObjectWrapperFactory objectWrapperFactory;
-
-    @Inject
-    private Class<? extends LanguageDriver> defaultScriptingLanguageType;
 
     @com.google.inject.Inject(optional = true)
     @TypeAliases
@@ -124,15 +64,17 @@ public class ConfigurationProvider implements Provider<Configuration> {
     private Set<Interceptor> plugins = Collections.emptySet();
 
     @com.google.inject.Inject(optional = true)
-    @Named("mybatis.configuration.mapUnderscoreToCamelCase")
-    private boolean mapUnderscoreToCamelCase = false;
-
-    @com.google.inject.Inject(optional = true)
     private DatabaseIdProvider databaseIdProvider;
 
     @com.google.inject.Inject
     private DataSource dataSource;
+    
+    @com.google.inject.Inject(optional = true)
+    @ConfigurationSettings
+    private Set<ConfigurationSetting> configurationSettings = Collections.emptySet();
 
+    private boolean failFast;
+    
     /**
      * @since 1.0.1
      */
@@ -147,62 +89,6 @@ public class ConfigurationProvider implements Provider<Configuration> {
     }
 
     /**
-     * @since 1.0.1
-     */
-    public void setLazyLoadingEnabled(boolean lazyLoadingEnabled) {
-        this.lazyLoadingEnabled = lazyLoadingEnabled;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setAggressiveLazyLoading(boolean aggressiveLazyLoading) {
-        this.aggressiveLazyLoading = aggressiveLazyLoading;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setMultipleResultSetsEnabled(boolean multipleResultSetsEnabled) {
-        this.multipleResultSetsEnabled = multipleResultSetsEnabled;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setUseGeneratedKeys(boolean useGeneratedKeys) {
-        this.useGeneratedKeys = useGeneratedKeys;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setUseColumnLabel(boolean useColumnLabel) {
-        this.useColumnLabel = useColumnLabel;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setCacheEnabled(boolean cacheEnabled) {
-        this.cacheEnabled = cacheEnabled;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setDefaultExecutorType(ExecutorType defaultExecutorType) {
-        this.defaultExecutorType = defaultExecutorType;
-    }
-
-    /**
-     * @since 1.0.1
-     */
-    protected void setAutoMappingBehavior(AutoMappingBehavior autoMappingBehavior) {
-        this.autoMappingBehavior = autoMappingBehavior;
-    }
-
-    /**
      * Flag to check all statements are completed.
      *
      * @param failFast flag to check all statements are completed
@@ -210,14 +96,6 @@ public class ConfigurationProvider implements Provider<Configuration> {
      */
     public void setFailFast(boolean failFast) {
         this.failFast = failFast;
-    }
-
-    public void setCallSettersOnNulls(boolean callSettersOnNulls) {
-        this.callSettersOnNulls = callSettersOnNulls;
-    }
-
-    public void setDefaultStatementTimeout(Integer defaultStatementTimeout) {
-        this.defaultStatementTimeout = defaultStatementTimeout;
     }
 
     /**
@@ -249,24 +127,6 @@ public class ConfigurationProvider implements Provider<Configuration> {
     }
 
     /**
-     * Adds the user defined ObjectFactory to the myBatis Configuration.
-     *
-     * @param objectFactory
-     */
-    public void setObjectFactory(final ObjectFactory objectFactory) {
-        this.objectFactory = objectFactory;
-    }
-
-    /**
-     * Adds the user defined ObjectWrapperFactory to the myBatis Configuration.
-     *
-     * @param objectWrapperFactory
-     */
-    public void setWrapperObjectFactory(final ObjectWrapperFactory objectWrapperFactory) {
-        this.objectWrapperFactory = objectWrapperFactory;
-    }
-
-    /**
      * Registers the user defined plugins interceptors to the
      * myBatis Configuration.
      *
@@ -275,14 +135,9 @@ public class ConfigurationProvider implements Provider<Configuration> {
     public void setPlugins(Set<Interceptor> plugins) {
         this.plugins = plugins;
     }
-
-    /**
-     * @since 3.3
-     * @param mapUnderscoreToCamelCase
-     */
-    public void mapUnderscoreToCamelCase( boolean mapUnderscoreToCamelCase )
-    {
-        this.mapUnderscoreToCamelCase = mapUnderscoreToCamelCase;
+    
+    public void setConfigurationSettings(Set<ConfigurationSetting> configurationSettings){
+    	this.configurationSettings = configurationSettings;
     }
 
     /**
@@ -299,21 +154,11 @@ public class ConfigurationProvider implements Provider<Configuration> {
     @Override
     public Configuration get() {
         final Configuration configuration = newConfiguration(environment);
-        configuration.setLazyLoadingEnabled(lazyLoadingEnabled);
-        configuration.setAggressiveLazyLoading(aggressiveLazyLoading);
-        configuration.setMultipleResultSetsEnabled(multipleResultSetsEnabled);
-        configuration.setUseGeneratedKeys(useGeneratedKeys);
-        configuration.setUseColumnLabel(useColumnLabel);
-        configuration.setCacheEnabled(cacheEnabled);
-        configuration.setDefaultExecutorType(defaultExecutorType);
-        configuration.setAutoMappingBehavior(autoMappingBehavior);
-        configuration.setObjectFactory(objectFactory);
-        configuration.setObjectWrapperFactory(objectWrapperFactory);
-        configuration.setDefaultScriptingLanguage(defaultScriptingLanguageType);
-        configuration.setMapUnderscoreToCamelCase( mapUnderscoreToCamelCase );
-        configuration.setCallSettersOnNulls(callSettersOnNulls);
-        configuration.setDefaultStatementTimeout(defaultStatementTimeout);
 
+        for(ConfigurationSetting setting : configurationSettings){
+        	setting.applyConfigurationSetting(configuration);
+        }
+        
         try {
             if (databaseIdProvider != null) {
                 configuration.setDatabaseId(databaseIdProvider.getDatabaseId(dataSource));

--- a/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
@@ -31,6 +31,7 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.TypeHandler;
 import org.mybatis.guice.configuration.settings.ConfigurationSetting;
 import org.mybatis.guice.configuration.settings.ConfigurationSettings;
+import org.mybatis.guice.configuration.settings.FailFastSetting;
 
 import com.google.inject.ProvisionException;
 
@@ -73,6 +74,8 @@ public class ConfigurationProvider implements Provider<Configuration> {
     @ConfigurationSettings
     private Set<ConfigurationSetting> configurationSettings = Collections.emptySet();
 
+    @com.google.inject.Inject(optional = true)
+    @FailFastSetting
     private boolean failFast;
     
     /**

--- a/src/main/java/org/mybatis/guice/configuration/settings/AggressiveLazyLoadingConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/AggressiveLazyLoadingConfigurationSetting.java
@@ -1,0 +1,17 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class AggressiveLazyLoadingConfigurationSetting implements ConfigurationSetting {
+
+	private final boolean aggressiveLazyLoading;
+	
+	public AggressiveLazyLoadingConfigurationSetting(final boolean aggressiveLazyLoading) {
+		this.aggressiveLazyLoading = aggressiveLazyLoading;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setAggressiveLazyLoading(aggressiveLazyLoading);
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/AutoMappingBehaviorConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/AutoMappingBehaviorConfigurationSetting.java
@@ -1,0 +1,17 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.AutoMappingBehavior;
+import org.apache.ibatis.session.Configuration;
+
+public class AutoMappingBehaviorConfigurationSetting implements ConfigurationSetting {
+
+	private final AutoMappingBehavior autoMappingBehavior;
+	public AutoMappingBehaviorConfigurationSetting(final AutoMappingBehavior autoMappingBehavior) {
+		this.autoMappingBehavior = autoMappingBehavior;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setAutoMappingBehavior(autoMappingBehavior);
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/CacheEnabledConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/CacheEnabledConfigurationSetting.java
@@ -1,0 +1,17 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class CacheEnabledConfigurationSetting implements ConfigurationSetting  {
+
+	private final boolean useCacheEnabled;
+	
+	public CacheEnabledConfigurationSetting(final boolean useCacheEnabled) {
+		this.useCacheEnabled = useCacheEnabled;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setCacheEnabled(useCacheEnabled);
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/CallSettersOnNullsConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/CallSettersOnNullsConfigurationSetting.java
@@ -1,0 +1,17 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class CallSettersOnNullsConfigurationSetting implements ConfigurationSetting  {
+
+	private final boolean callSettersOnNulls;
+	
+	public CallSettersOnNullsConfigurationSetting(final boolean callSettersOnNulls){
+		this.callSettersOnNulls = callSettersOnNulls;
+	}
+	
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setCallSettersOnNulls(callSettersOnNulls);
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/ConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/ConfigurationSetting.java
@@ -1,0 +1,7 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public interface ConfigurationSetting {
+	public void applyConfigurationSetting(Configuration configuration);
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/ConfigurationSettings.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/ConfigurationSettings.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+/**
+ * Marker for ConfigurationSetting interfaces.
+ */
+@BindingAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ConfigurationSettings {
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/DefaultExecutorTypeConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/DefaultExecutorTypeConfigurationSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.ExecutorType;
+
+public class DefaultExecutorTypeConfigurationSetting implements ConfigurationSetting  {
+
+	private final ExecutorType executorType;
+	
+	public DefaultExecutorTypeConfigurationSetting(final ExecutorType executorType) {
+		this.executorType = executorType;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setDefaultExecutorType(executorType);
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/DefaultScriptingLanguageTypeConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/DefaultScriptingLanguageTypeConfigurationSetting.java
@@ -1,0 +1,20 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.scripting.LanguageDriver;
+import org.apache.ibatis.session.Configuration;
+
+public class DefaultScriptingLanguageTypeConfigurationSetting implements ConfigurationSetting  {
+
+	private final Class<? extends LanguageDriver> defaultScriptingLanguageType;
+	
+	public DefaultScriptingLanguageTypeConfigurationSetting(
+			Class<? extends LanguageDriver> defaultScriptingLanguageType) {
+		this.defaultScriptingLanguageType = defaultScriptingLanguageType;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setDefaultScriptingLanguage(defaultScriptingLanguageType);
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/DefaultStatementTimeoutConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/DefaultStatementTimeoutConfigurationSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class DefaultStatementTimeoutConfigurationSetting implements ConfigurationSetting  {
+	
+	private final Integer defaultStatementTimeout;
+	
+	public DefaultStatementTimeoutConfigurationSetting(Integer defaultStatementTimeout) {
+		this.defaultStatementTimeout = defaultStatementTimeout;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setDefaultStatementTimeout(defaultStatementTimeout);
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/FailFastSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/FailFastSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+/**
+ * Marker for FailFastSetting boolean.
+ */
+@BindingAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface FailFastSetting {
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/FailFastSettingImpl.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/FailFastSettingImpl.java
@@ -1,0 +1,15 @@
+package org.mybatis.guice.configuration.settings;
+
+import java.lang.annotation.Annotation;
+
+public class FailFastSettingImpl implements FailFastSetting {
+
+	@Override
+	public Class<? extends Annotation> annotationType() {
+		return FailFastSetting.class;
+	}
+	
+	public static FailFastSetting get(){
+		return new FailFastSettingImpl();
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/LazyLoadingEnabledConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/LazyLoadingEnabledConfigurationSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class LazyLoadingEnabledConfigurationSetting implements ConfigurationSetting  {
+
+	private final boolean lazyLoadingEnabled;
+	
+	public LazyLoadingEnabledConfigurationSetting(final boolean lazyLoadingEnabled) {
+		this.lazyLoadingEnabled = lazyLoadingEnabled;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setLazyLoadingEnabled(lazyLoadingEnabled);
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/LocalCacheScopeConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/LocalCacheScopeConfigurationSetting.java
@@ -1,0 +1,19 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.LocalCacheScope;
+
+public class LocalCacheScopeConfigurationSetting implements ConfigurationSetting {
+
+	private final LocalCacheScope localCacheScope;
+	
+	public LocalCacheScopeConfigurationSetting(final LocalCacheScope localCacheScope){
+		this.localCacheScope = localCacheScope;
+	}
+	
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setLocalCacheScope(localCacheScope);
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/MapUnderscoreToCamelCaseConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/MapUnderscoreToCamelCaseConfigurationSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class MapUnderscoreToCamelCaseConfigurationSetting implements ConfigurationSetting {
+
+	private final boolean mapUnderscoreToCamelCase;
+	
+	public MapUnderscoreToCamelCaseConfigurationSetting(final boolean mapUnderscoreToCamelCase) {
+		this.mapUnderscoreToCamelCase = mapUnderscoreToCamelCase;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setMapUnderscoreToCamelCase(mapUnderscoreToCamelCase);
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/MultipleResultSetsEnabledConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/MultipleResultSetsEnabledConfigurationSetting.java
@@ -1,0 +1,17 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class MultipleResultSetsEnabledConfigurationSetting implements ConfigurationSetting {
+	
+	private final boolean multipleResultSetsEnabled;
+
+	public MultipleResultSetsEnabledConfigurationSetting(final boolean multipleResultSetsEnabled) {
+		this.multipleResultSetsEnabled = multipleResultSetsEnabled;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setMultipleResultSetsEnabled(multipleResultSetsEnabled);
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/ObjectFactoryConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/ObjectFactoryConfigurationSetting.java
@@ -1,0 +1,37 @@
+package org.mybatis.guice.configuration.settings;
+
+
+import org.apache.ibatis.reflection.factory.ObjectFactory;
+import org.apache.ibatis.session.Configuration;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+
+public class ObjectFactoryConfigurationSetting implements Provider<ConfigurationSetting> {
+
+	@Inject
+	private Injector injector;
+	
+	private final Class<? extends ObjectFactory> objectFactoryType;
+	
+	public ObjectFactoryConfigurationSetting(Class<? extends ObjectFactory> objectFactoryType) {
+		this.objectFactoryType = objectFactoryType;
+	}
+
+	public void setInjector(final Injector injector){
+		this.injector = injector;
+	}
+
+	@Override
+	public ConfigurationSetting get() {
+		final ObjectFactory objectFactory = injector.getInstance(objectFactoryType);
+		return new ConfigurationSetting(){
+			@Override
+			public void applyConfigurationSetting(Configuration configuration) {
+				configuration.setObjectFactory(objectFactory);
+			}
+		};
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/ObjectWrapperFactoryConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/ObjectWrapperFactoryConfigurationSetting.java
@@ -1,0 +1,35 @@
+package org.mybatis.guice.configuration.settings;
+
+
+import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
+import org.apache.ibatis.session.Configuration;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+
+public class ObjectWrapperFactoryConfigurationSetting implements Provider<ConfigurationSetting> {
+
+	@Inject
+	private Injector injector;
+	private final Class<? extends ObjectWrapperFactory> objectWrapperFactoryType;
+	
+	public ObjectWrapperFactoryConfigurationSetting(Class<? extends ObjectWrapperFactory> objectWrapperFactoryType) {
+		this.objectWrapperFactoryType = objectWrapperFactoryType;
+	}
+
+	public void setInjector(final Injector injector){
+		this.injector = injector;
+	}
+
+	@Override
+	public ConfigurationSetting get() {
+		final ObjectWrapperFactory objectWrapperFactory = injector.getInstance(objectWrapperFactoryType);
+		return new ConfigurationSetting(){
+			@Override
+			public void applyConfigurationSetting(Configuration configuration) {
+				configuration.setObjectWrapperFactory(objectWrapperFactory);
+			}
+		};
+	}
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/UseColumnLabelConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/UseColumnLabelConfigurationSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class UseColumnLabelConfigurationSetting implements ConfigurationSetting {
+
+	private final boolean useColumnLabel;
+	
+	public UseColumnLabelConfigurationSetting(final boolean useColumnLabel) {
+		this.useColumnLabel = useColumnLabel;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setUseColumnLabel(useColumnLabel);
+	}
+
+}

--- a/src/main/java/org/mybatis/guice/configuration/settings/UseGeneratedKeysConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/UseGeneratedKeysConfigurationSetting.java
@@ -1,0 +1,18 @@
+package org.mybatis.guice.configuration.settings;
+
+import org.apache.ibatis.session.Configuration;
+
+public class UseGeneratedKeysConfigurationSetting implements ConfigurationSetting {
+
+	private final boolean useGeneratedKeys;
+	
+	public UseGeneratedKeysConfigurationSetting(final boolean useGeneratedKeys) {
+		this.useGeneratedKeys = useGeneratedKeys;
+	}
+
+	@Override
+	public void applyConfigurationSetting(Configuration configuration) {
+		configuration.setUseGeneratedKeys(useGeneratedKeys);
+	}
+
+}


### PR DESCRIPTION
The main focus of this suggestion is to allow developers to alter Configuration settings as they are added/updated in the core mybatis repo. This is made possible with hooks into the ConfigurationProvider without the need for "mybatis.configuration.XXX" bindings nor MyBatisModule convenience methods.

I would love to hear any feedback, questions or concerns. If there are any further changes or alterations to what I am proposing, I would be happy to continue working.

Thanks!
