### PR TITLE
mistake in getting_start doc 

### DIFF
--- a/src/site/xdoc/getting-started.xml
+++ b/src/site/xdoc/getting-started.xml
@@ -136,7 +136,7 @@ Injector injector = Guice.createInjector(
             bindTransactionFactoryType(JdbcTransactionFactory.class);
             addMapperClass(UserMapper.class);
 
-            Names.bindProperties(binder, createTestProperties());
+            Names.bindProperties(binder(), createTestProperties());
             bind(FooService.class).to(FooServiceMapperImpl.class);
         }
 


### PR DESCRIPTION
example for MyBatisModule.initialize
change binder to binder(),since binder is package access