### PR TITLE
Undo configuration provider injector hack

### DIFF
--- a/src/main/java/org/mybatis/guice/MyBatisModule.java
+++ b/src/main/java/org/mybatis/guice/MyBatisModule.java
@@ -241,10 +241,10 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
         ConfigurationProviderProvisionListener.create(configurationSetting));
   }
 
-  public void bindConfigurationSettingProvider(
-      final Provider<? extends ConfigurationSetting> configurationSettingProvider) {
+  public <P extends Provider<? extends ConfigurationSetting>> void bindConfigurationSettingProvider(
+      P configurationSettingProvider) {
     bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
-        ConfigurationProviderProvisionListener.create(configurationSettingProvider));
+        ConfigurationProviderProvisionListener.create(configurationSettingProvider, binder()));
   }
 
   private final void bindBoolean(String name, boolean value) {
@@ -485,7 +485,7 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
         checkArgument(handler != null, "TypeHandler must not be null for '%s'", type.getName());
 
         bindTypeHandler(TypeLiteral.get(handler));
-        bindConfigurationSettingProvider(new JavaTypeAndHandlerConfigurationSettingProvider<T>(type, Key.get(handler)));
+        bindConfigurationSettingProvider(JavaTypeAndHandlerConfigurationSettingProvider.create(type, Key.get(handler)));
       }
 
       @Override
@@ -493,7 +493,7 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
         checkArgument(handler != null, "TypeHandler must not be null for '%s'", type.getName());
 
         bindTypeHandler(handler);
-        bindConfigurationSettingProvider(new JavaTypeAndHandlerConfigurationSettingProvider<T>(type, Key.get(handler)));
+        bindConfigurationSettingProvider(JavaTypeAndHandlerConfigurationSettingProvider.create(type, Key.get(handler)));
       }
 
       @Override
@@ -501,7 +501,7 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
         checkArgument(handler != null, "TypeHandler must not be null for '%s'", type.getName());
 
         bindProvidedTypeHandler(TypeLiteral.get(handler), type);
-        bindConfigurationSettingProvider(new JavaTypeAndHandlerConfigurationSettingProvider<T>(type, Key.get(handler)));
+        bindConfigurationSettingProvider(JavaTypeAndHandlerConfigurationSettingProvider.create(type, Key.get(handler)));
       }
 
       @Override
@@ -509,7 +509,7 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
         checkArgument(handler != null, "TypeHandler must not be null for '%s'", type.getName());
 
         bindProvidedTypeHandler(handler, type);
-        bindConfigurationSettingProvider(new JavaTypeAndHandlerConfigurationSettingProvider<T>(type, Key.get(handler)));
+        bindConfigurationSettingProvider(JavaTypeAndHandlerConfigurationSettingProvider.create(type, Key.get(handler)));
       }
 
       final <TH extends TypeHandler<? extends T>> void bindTypeHandler(TypeLiteral<TH> typeHandlerType) {
@@ -608,7 +608,8 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
   protected final void addMapperClass(Class<?> mapperClass) {
     checkArgument(mapperClass != null, "Parameter 'mapperClass' must not be null");
 
-    bindConfigurationSetting(new MapperConfigurationSetting(mapperClass));
+    bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
+        ConfigurationProviderProvisionListener.create(new MapperConfigurationSetting(mapperClass)));
     bindMapper(mapperClass);
   }
 

--- a/src/main/java/org/mybatis/guice/MyBatisModule.java
+++ b/src/main/java/org/mybatis/guice/MyBatisModule.java
@@ -236,12 +236,12 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
     bindConfigurationSetting(new DefaultStatementTimeoutConfigurationSetting(defaultStatementTimeout));
   }
 
-  public void bindConfigurationSetting(final ConfigurationSetting configurationSetting) {
+  protected final void bindConfigurationSetting(final ConfigurationSetting configurationSetting) {
     bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
         ConfigurationProviderProvisionListener.create(configurationSetting));
   }
 
-  public <P extends Provider<? extends ConfigurationSetting>> void bindConfigurationSettingProvider(
+  protected final <P extends Provider<? extends ConfigurationSetting>> void bindConfigurationSettingProvider(
       P configurationSettingProvider) {
     bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
         ConfigurationProviderProvisionListener.create(configurationSettingProvider, binder()));

--- a/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
@@ -105,9 +105,6 @@ public class ConfigurationProvider implements Provider<Configuration> {
   private Set<ConfigurationSetting> configurationSettings = new HashSet<ConfigurationSetting>();
   private Set<MapperConfigurationSetting> mapperConfigurationSettings = new HashSet<MapperConfigurationSetting>();
 
-  @com.google.inject.Inject
-  private Injector injector;
-
   /**
    * @since 1.0.1
    */
@@ -132,15 +129,12 @@ public class ConfigurationProvider implements Provider<Configuration> {
     this.failFast = failFast;
   }
 
-  public void addConfigurationSettingProvider(
-      final Provider<? extends ConfigurationSetting> configurationSettingProvider) {
-    injector.injectMembers(configurationSettingProvider);
-    ConfigurationSetting configurationSetting = configurationSettingProvider.get();
-    if (configurationSetting instanceof MapperConfigurationSetting) {
-      this.mapperConfigurationSettings.add((MapperConfigurationSetting) configurationSetting);
-    } else {
-      this.configurationSettings.add(configurationSetting);
-    }
+  public void addConfigurationSetting(ConfigurationSetting configurationSetting) {
+    this.configurationSettings.add(configurationSetting);
+  }
+  
+  public void addMapperConfigurationSetting(MapperConfigurationSetting mapperConfigurationSetting) {
+    this.mapperConfigurationSettings.add((MapperConfigurationSetting) mapperConfigurationSetting);
   }
 
   /**

--- a/src/main/java/org/mybatis/guice/configuration/settings/MapperConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/MapperConfigurationSetting.java
@@ -17,7 +17,7 @@ package org.mybatis.guice.configuration.settings;
 
 import org.apache.ibatis.session.Configuration;
 
-public final class MapperConfigurationSetting implements ConfigurationSetting {
+public final class MapperConfigurationSetting {
 
   private final Class<?> mapperClass;
 
@@ -25,7 +25,6 @@ public final class MapperConfigurationSetting implements ConfigurationSetting {
     this.mapperClass = mapperClass;
   }
 
-  @Override
   public void applyConfigurationSetting(Configuration configuration) {
     if (!configuration.hasMapper(mapperClass)) {
       configuration.addMapper(mapperClass);


### PR DESCRIPTION
Hi,

This is an addendum to my last PR. I wanted to find a way around making the ConfigurationProvider dependent on the Injector just for the purpose of injecting each of the Settings.

Here, I found a way around it by letting the ProvisionListener handle it with a MembersInjector.

Also, settings that don't require injection no longer get wrapped in providers and Mapper Settings are explicitly handled separately.