### PR TITLE
Fix custom configuration provider

### DIFF
--- a/src/main/java/org/mybatis/guice/MyBatisModule.java
+++ b/src/main/java/org/mybatis/guice/MyBatisModule.java
@@ -15,20 +15,9 @@
  */
 package org.mybatis.guice;
 
-import static com.google.inject.name.Names.named;
-import static com.google.inject.util.Providers.guicify;
-import static org.mybatis.guice.Preconditions.checkArgument;
-
 import com.google.inject.Key;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
-
-import java.util.Collection;
-import java.util.Set;
-
-import javax.inject.Provider;
-import javax.sql.DataSource;
-
 import org.apache.ibatis.io.ResolverUtil;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.apache.ibatis.mapping.Environment;
@@ -39,42 +28,29 @@ import org.apache.ibatis.reflection.wrapper.DefaultObjectWrapperFactory;
 import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
-import org.apache.ibatis.session.AutoMappingBehavior;
-import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.ExecutorType;
-import org.apache.ibatis.session.LocalCacheScope;
-import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.*;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.type.Alias;
 import org.apache.ibatis.type.TypeHandler;
 import org.mybatis.guice.binder.AliasBinder;
 import org.mybatis.guice.binder.TypeHandlerBinder;
 import org.mybatis.guice.configuration.ConfigurationProvider;
-import org.mybatis.guice.configuration.settings.AggressiveLazyLoadingConfigurationSetting;
-import org.mybatis.guice.configuration.settings.AliasConfigurationSetting;
-import org.mybatis.guice.configuration.settings.AutoMappingBehaviorConfigurationSetting;
-import org.mybatis.guice.configuration.settings.CacheEnabledConfigurationSetting;
-import org.mybatis.guice.configuration.settings.ConfigurationSetting;
-import org.mybatis.guice.configuration.settings.DefaultExecutorTypeConfigurationSetting;
-import org.mybatis.guice.configuration.settings.DefaultScriptingLanguageTypeConfigurationSetting;
-import org.mybatis.guice.configuration.settings.DefaultStatementTimeoutConfigurationSetting;
-import org.mybatis.guice.configuration.settings.InterceptorConfigurationSettingProvider;
-import org.mybatis.guice.configuration.settings.JavaTypeAndHandlerConfigurationSettingProvider;
-import org.mybatis.guice.configuration.settings.LazyLoadingEnabledConfigurationSetting;
-import org.mybatis.guice.configuration.settings.LocalCacheScopeConfigurationSetting;
-import org.mybatis.guice.configuration.settings.MapUnderscoreToCamelCaseConfigurationSetting;
-import org.mybatis.guice.configuration.settings.MapperConfigurationSetting;
-import org.mybatis.guice.configuration.settings.MultipleResultSetsEnabledConfigurationSetting;
-import org.mybatis.guice.configuration.settings.ObjectFactoryConfigurationSetting;
-import org.mybatis.guice.configuration.settings.ObjectWrapperFactoryConfigurationSetting;
-import org.mybatis.guice.configuration.settings.TypeHandlerConfigurationSettingProvider;
-import org.mybatis.guice.configuration.settings.UseColumnLabelConfigurationSetting;
-import org.mybatis.guice.configuration.settings.UseGeneratedKeysConfigurationSetting;
+import org.mybatis.guice.configuration.ConfigurationSettingListener;
+import org.mybatis.guice.configuration.settings.*;
 import org.mybatis.guice.environment.EnvironmentProvider;
 import org.mybatis.guice.provision.ConfigurationProviderProvisionListener;
 import org.mybatis.guice.provision.KeyMatcher;
 import org.mybatis.guice.session.SqlSessionFactoryProvider;
 import org.mybatis.guice.type.TypeHandlerProvider;
+
+import javax.inject.Provider;
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.google.inject.name.Names.named;
+import static com.google.inject.util.Providers.guicify;
+import static org.mybatis.guice.Preconditions.checkArgument;
 
 /**
  * Easy to use helper Module that alleviates users to write the boilerplate
@@ -237,13 +213,13 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
   }
 
   protected final void bindConfigurationSetting(final ConfigurationSetting configurationSetting) {
-    bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
+    bindListener(KeyMatcher.create(Key.get(ConfigurationSettingListener.class)),
         ConfigurationProviderProvisionListener.create(configurationSetting));
   }
 
   protected final <P extends Provider<? extends ConfigurationSetting>> void bindConfigurationSettingProvider(
       P configurationSettingProvider) {
-    bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
+    bindListener(KeyMatcher.create(Key.get(ConfigurationSettingListener.class)),
         ConfigurationProviderProvisionListener.create(configurationSettingProvider, binder()));
   }
 
@@ -608,7 +584,7 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
   protected final void addMapperClass(Class<?> mapperClass) {
     checkArgument(mapperClass != null, "Parameter 'mapperClass' must not be null");
 
-    bindListener(KeyMatcher.create(Key.get(ConfigurationProvider.class)),
+    bindListener(KeyMatcher.create(Key.get(ConfigurationSettingListener.class)),
         ConfigurationProviderProvisionListener.create(new MapperConfigurationSetting(mapperClass)));
     bindMapper(mapperClass);
   }

--- a/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
@@ -15,7 +15,6 @@
  */
 package org.mybatis.guice.configuration;
 
-import com.google.inject.Injector;
 import com.google.inject.ProvisionException;
 import com.google.inject.name.Named;
 
@@ -40,7 +39,7 @@ import org.mybatis.guice.configuration.settings.MapperConfigurationSetting;
  * Provides the myBatis Configuration.
  */
 @Singleton
-public class ConfigurationProvider implements Provider<Configuration> {
+public class ConfigurationProvider implements Provider<Configuration>, ConfigurationSettingListener {
 
   /**
    * The myBatis Configuration reference.
@@ -129,10 +128,12 @@ public class ConfigurationProvider implements Provider<Configuration> {
     this.failFast = failFast;
   }
 
+  @Override
   public void addConfigurationSetting(ConfigurationSetting configurationSetting) {
     this.configurationSettings.add(configurationSetting);
   }
 
+  @Override
   public void addMapperConfigurationSetting(MapperConfigurationSetting mapperConfigurationSetting) {
     this.mapperConfigurationSettings.add((MapperConfigurationSetting) mapperConfigurationSetting);
   }

--- a/src/main/java/org/mybatis/guice/configuration/ConfigurationSettingListener.java
+++ b/src/main/java/org/mybatis/guice/configuration/ConfigurationSettingListener.java
@@ -1,0 +1,27 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.guice.configuration;
+
+import org.mybatis.guice.configuration.settings.ConfigurationSetting;
+import org.mybatis.guice.configuration.settings.MapperConfigurationSetting;
+
+public interface ConfigurationSettingListener {
+
+    void addConfigurationSetting(ConfigurationSetting configurationSetting);
+
+    void addMapperConfigurationSetting(MapperConfigurationSetting mapperConfigurationSetting);
+
+}

--- a/src/main/java/org/mybatis/guice/provision/KeyMatcher.java
+++ b/src/main/java/org/mybatis/guice/provision/KeyMatcher.java
@@ -1,17 +1,17 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mybatis.guice.provision;
 
@@ -20,18 +20,18 @@ import com.google.inject.Key;
 import com.google.inject.matcher.AbstractMatcher;
 
 public final class KeyMatcher<T> extends AbstractMatcher<Binding<?>> {
-  private final Key<T> key;
+    private final Key<T> key;
 
-  KeyMatcher(Key<T> key) {
-    this.key = key;
-  }
+    KeyMatcher(Key<T> key) {
+        this.key = key;
+    }
 
-  @Override
-  public boolean matches(Binding<?> t) {
-    return key.equals(t.getKey());
-  }
+    public static <T> KeyMatcher<T> create(Key<T> key) {
+        return new KeyMatcher<T>(key);
+    }
 
-  public static <T> KeyMatcher<T> create(Key<T> key) {
-    return new KeyMatcher<T>(key);
-  }
+    @Override
+    public boolean matches(Binding<?> t) {
+        return key.getTypeLiteral().getRawType().isAssignableFrom(t.getKey().getTypeLiteral().getRawType());
+    }
 }

--- a/src/test/java/org/mybatis/guice/MyBatisModuleTest.java
+++ b/src/test/java/org/mybatis/guice/MyBatisModuleTest.java
@@ -15,35 +15,15 @@
  */
 package org.mybatis.guice;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.google.inject.CreationException;
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.google.inject.Key;
-import com.google.inject.Provider;
-import com.google.inject.TypeLiteral;
-
+import com.google.inject.*;
 import org.apache.ibatis.io.ResolverUtil;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
+import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
 import org.apache.ibatis.reflection.wrapper.DefaultObjectWrapperFactory;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
-import org.apache.ibatis.session.AutoMappingBehavior;
-import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.ExecutorType;
-import org.apache.ibatis.session.LocalCacheScope;
-import org.apache.ibatis.session.SqlSession;
-import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.*;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.apache.ibatis.type.Alias;
@@ -54,6 +34,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+import org.mybatis.guice.configuration.ConfigurationProvider;
 import org.mybatis.guice.configuration.ErrorMapper;
 import org.mybatis.guice.configuration.settings.ConfigurationSetting;
 import org.mybatis.guice.generictypehandler.CustomObject;
@@ -67,15 +48,13 @@ import org.mybatis.guice.resolver.mapper.SecondMapper;
 import org.mybatis.guice.resolver.typehandler.AddressTypeHandler;
 import org.mybatis.guice.resolver.typehandler.UserTypeHandler;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
-
 import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 public class MyBatisModuleTest {
   @Mock
@@ -1417,7 +1396,13 @@ public class MyBatisModuleTest {
     assertNotNull(injector.getInstance(SecondMapper.class));
   }
 
-  public static class TestConfigurationProvider implements Provider<Configuration> {
+  public static class TestConfigurationProvider extends ConfigurationProvider {
+
+    @Inject
+    public TestConfigurationProvider(Environment environment) {
+      super(environment);
+    }
+
     @Override
     public Configuration get() {
       return staticConfiguration;

--- a/src/test/java/org/mybatis/guice/customconfiguration/CustomConfigurationTest.java
+++ b/src/test/java/org/mybatis/guice/customconfiguration/CustomConfigurationTest.java
@@ -51,10 +51,14 @@ public class CustomConfigurationTest {
         useConfigurationProvider(MyConfigurationProvider.class);
         bindDataSourceProviderType(PooledDataSourceProvider.class);
         bindTransactionFactoryType(JdbcTransactionFactory.class);
+
+        lazyLoadingEnabled(true);
       }
     });
     Configuration configuration = injector.getInstance(Configuration.class);
     assertTrue("Configuration not an instanceof MyConfiguration",
         MyConfiguration.class.isAssignableFrom(configuration.getClass()));
+    assertTrue("Configuration return true of lazy loading",
+            configuration.isLazyLoadingEnabled());
   }
 }


### PR DESCRIPTION
Patch for solution 1. See #118 

- Change `KeyMatcher` for use `isAssignableFrom`
- Add interface `ConfigurationSettingListener`
- Change `MyBatisModule`