### PR TITLE
Cleanup issues with release (findbugs needed changed to spotbugs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /target
 /derby.log
 .mvn/wrapper/maven-wrapper.jar
+release.properties
+pom.xml.releaseBackup

--- a/pom.xml
+++ b/pom.xml
@@ -131,10 +131,10 @@
      | Optional dependencies
     -->
     <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>3.0.2</version>
-        <optional>true</optional>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,12 @@
 
   <properties>
     <clirr.comparisonVersion>3.10</clirr.comparisonVersion>
-    <findbugs.onlyAnalyze>org.mybatis.guice.*</findbugs.onlyAnalyze>
+    <spotbugs.onlyAnalyze>org.mybatis.guice.*</spotbugs.onlyAnalyze>
     <gcu.product>Guice</gcu.product>
     <guice.version>4.2.2</guice.version>
     <ejb-api.version>3.2.6</ejb-api.version>
     <osgi.import>com.alibaba.druid.pool.*;resolution:=optional,com.jolbox.bonecp.*;resolution:=optional,com.mchange.v2.c3p0.*;resolution:=optional,org.apache.commons.dbcp2.*;resolution:=optional,javax.transaction.*;resolution:=optional</osgi.import>
-    <findbugs.omitVisitors>UnreadFields</findbugs.omitVisitors>
+    <spotbugs.omitVisitors>UnreadFields</spotbugs.omitVisitors>
     <module.name>org.mybatis.guice</module.name>
 
     <!-- Override jacoco to latest until on mybatis-parent 32 -->

--- a/src/test/java/org/mybatis/guice/datasource/bonecp/BoneCPProviderTest.java
+++ b/src/test/java/org/mybatis/guice/datasource/bonecp/BoneCPProviderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The release was done mostly manually.  The site was ran via site site:deploy.  The release was discarded due to invalid pom entry and simply ran as deploy with pom adjusted per commit 4dcffe4.  Next time should go much smoother.