### PR TITLE
#782 multipleResultSetsEnabled has been deprecated in core 3.5.17

### DIFF
--- a/src/main/java/org/mybatis/guice/MyBatisModule.java
+++ b/src/main/java/org/mybatis/guice/MyBatisModule.java
@@ -160,6 +160,8 @@ public abstract class MyBatisModule extends AbstractMyBatisModule {
   /**
    * Multiple result sets enabled.
    *
+   * @deprecated this option has no effect
+   *
    * @param multipleResultSetsEnabled
    *          the multiple result sets enabled
    */

--- a/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
+++ b/src/main/java/org/mybatis/guice/configuration/ConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package org.mybatis.guice.configuration;
 
 import com.google.inject.ProvisionException;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import jakarta.inject.Named;
 import jakarta.inject.Provider;
@@ -34,8 +36,6 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
 import org.mybatis.guice.configuration.settings.ConfigurationSetting;
 import org.mybatis.guice.configuration.settings.MapperConfigurationSetting;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Provides the myBatis Configuration.
@@ -56,6 +56,7 @@ public class ConfigurationProvider implements Provider<Configuration>, Configura
   @Named("mybatis.configuration.aggressiveLazyLoading")
   private boolean aggressiveLazyLoading = true;
 
+  @Deprecated
   @com.google.inject.Inject(optional = true)
   @Named("mybatis.configuration.multipleResultSetsEnabled")
   private boolean multipleResultSetsEnabled = true;
@@ -163,7 +164,6 @@ public class ConfigurationProvider implements Provider<Configuration>, Configura
     final Configuration configuration = newConfiguration(environment);
     configuration.setLazyLoadingEnabled(lazyLoadingEnabled);
     configuration.setAggressiveLazyLoading(aggressiveLazyLoading);
-    configuration.setMultipleResultSetsEnabled(multipleResultSetsEnabled);
     configuration.setUseGeneratedKeys(useGeneratedKeys);
     configuration.setUseColumnLabel(useColumnLabel);
     configuration.setCacheEnabled(cacheEnabled);

--- a/src/main/java/org/mybatis/guice/configuration/settings/MultipleResultSetsEnabledConfigurationSetting.java
+++ b/src/main/java/org/mybatis/guice/configuration/settings/MultipleResultSetsEnabledConfigurationSetting.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@ package org.mybatis.guice.configuration.settings;
 
 import org.apache.ibatis.session.Configuration;
 
+/**
+ * @deprecated This option has no effect.
+ */
 public class MultipleResultSetsEnabledConfigurationSetting implements ConfigurationSetting {
 
   private final boolean multipleResultSetsEnabled;

--- a/src/test/java/org/mybatis/guice/MyBatisModuleTest.java
+++ b/src/test/java/org/mybatis/guice/MyBatisModuleTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ import org.apache.ibatis.type.Alias;
 import org.apache.ibatis.type.TypeHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -272,6 +273,7 @@ class MyBatisModuleTest {
     assertEquals(true, configuration.isMultipleResultSetsEnabled());
   }
 
+  @Disabled("multipleResultSetsEnabled is deprecated")
   @Test
   void multipleResultSetsEnabled_False() {
     Injector injector = Guice.createInjector(new MyBatisModule() {

--- a/src/test/java/org/mybatis/guice/configuration/ConfigurationProviderTest.java
+++ b/src/test/java/org/mybatis/guice/configuration/ConfigurationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -104,7 +104,6 @@ class ConfigurationProviderTest {
     assertEquals(0, configuration.getInterceptors().size());
     assertFalse(configuration.isLazyLoadingEnabled());
     assertTrue(configuration.isAggressiveLazyLoading());
-    assertTrue(configuration.isMultipleResultSetsEnabled());
     assertFalse(configuration.isUseGeneratedKeys());
     assertTrue(configuration.isUseColumnLabel());
     assertTrue(configuration.isCacheEnabled());
@@ -130,7 +129,6 @@ class ConfigurationProviderTest {
         bind(DataSource.class).toInstance(dataSource);
         bindConstant().annotatedWith(Names.named("mybatis.configuration.lazyLoadingEnabled")).to(true);
         bindConstant().annotatedWith(Names.named("mybatis.configuration.aggressiveLazyLoading")).to(false);
-        bindConstant().annotatedWith(Names.named("mybatis.configuration.multipleResultSetsEnabled")).to(false);
         bindConstant().annotatedWith(Names.named("mybatis.configuration.useGeneratedKeys")).to(true);
         bindConstant().annotatedWith(Names.named("mybatis.configuration.useColumnLabel")).to(false);
         bindConstant().annotatedWith(Names.named("mybatis.configuration.cacheEnabled")).to(false);
@@ -183,7 +181,6 @@ class ConfigurationProviderTest {
     assertEquals(databaseId, configuration.getDatabaseId());
     assertTrue(configuration.isLazyLoadingEnabled());
     assertFalse(configuration.isAggressiveLazyLoading());
-    assertFalse(configuration.isMultipleResultSetsEnabled());
     assertTrue(configuration.isUseGeneratedKeys());
     assertFalse(configuration.isUseColumnLabel());
     assertFalse(configuration.isCacheEnabled());


### PR DESCRIPTION
https://github.com/mybatis/mybatis-3/pull/3238
