### PR TITLE
Potential fix for code scanning alert no. 71: Missing space in string literal

### DIFF
--- a/src/test/java/org/mybatis/guice/jta/BaseDB.java
+++ b/src/test/java/org/mybatis/guice/jta/BaseDB.java
@@ -48,7 +48,7 @@ public class BaseDB {
   static final String USER = "SA";
   static final String PASSWORD = "";
 
-  static final String QUERY_CREATE_TABLE = "create table table1 (" + "id integer not null,"
+  static final String QUERY_CREATE_TABLE = "create table table1 (" + "id integer not null, "
       + "name varchar(80) not null," + "constraint pk_table1 primary key (id) )";
   static final String QUERY_DROP_TABLE = "drop table table1";
   static final String QUERY_INSERT = "insert into table1 (id, name) values (?,?)";


### PR DESCRIPTION
Potential fix for [https://github.com/mybatis/guice/security/code-scanning/71](https://github.com/mybatis/guice/security/code-scanning/71)

To fix this, ensure a space exists at the string concatenation boundary in the SQL literal so the generated statement is unambiguous and readable.

Best single fix (no functional change intended): in `src/test/java/org/mybatis/guice/jta/BaseDB.java`, update `QUERY_CREATE_TABLE` so the first fragment ends with `", "` (comma + space) before concatenating the next fragment. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
